### PR TITLE
Fix wrong Year Byte calculation due to operator precedence

### DIFF
--- a/ds1302.py
+++ b/ds1302.py
@@ -93,7 +93,7 @@ class DS1302:
         byte_l[3] = (dt.tm_mday // 10) << 4 | dt.tm_mday % 10
         byte_l[4] = (dt.tm_mon // 10) << 4 | dt.tm_mon % 10
         byte_l[5] = 0
-        byte_l[6] = ((dt.tm_year-2000 // 10) << 4) | (dt.tm_year-2000) % 10
+        byte_l[6] = (((dt.tm_year-2000) // 10) << 4) | (dt.tm_year-2000) % 10
         self._start_tx()
         self._w_byte(0xbe)
         for byte in byte_l:


### PR DESCRIPTION
I've noticed that on Seeeduino Xiao

2021 - 2000 // 10 = 1821

instead of 2.
I've added parenthesis to fix precedence